### PR TITLE
GO-5117: fix empty bookmark

### DIFF
--- a/renderer/bookmark.go
+++ b/renderer/bookmark.go
@@ -9,23 +9,40 @@ import (
 
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
 
 func (r *Renderer) makeBookmarkBlockParams(b *model.Block) *BlockParams {
 	bookmark := b.GetBookmark()
 
+	details := r.getBookmarkDetails(bookmark)
+	return r.getBookmarkBlockParams(b, details)
+}
+
+func (r *Renderer) getBookmarkDetails(bookmark *model.BlockContentBookmark) *types.Struct {
 	targetObjectId := bookmark.GetTargetObjectId()
 	targetBookmark := r.getObjectSnapshot(targetObjectId)
 	if targetBookmark == nil {
-		return nil
+		// fallback to old logic with block
+		return r.getDetailsFromBlock(bookmark)
 	}
 
 	details := targetBookmark.GetSnapshot().GetData().GetDetails()
 	if details == nil || len(details.GetFields()) == 0 {
-		return nil
+		// fallback to old logic with block
+		return r.getDetailsFromBlock(bookmark)
 	}
+	return details
+}
 
-	return r.getBookmarkBlockParams(b, details)
+func (r *Renderer) getDetailsFromBlock(bookmark *model.BlockContentBookmark) *types.Struct {
+	return &types.Struct{Fields: map[string]*types.Value{
+		bundle.RelationKeyIconImage.String():   pbtypes.String(bookmark.GetFaviconHash()),
+		bundle.RelationKeyPicture.String():     pbtypes.String(bookmark.GetImageHash()),
+		bundle.RelationKeyDescription.String(): pbtypes.String(bookmark.GetDescription()),
+		bundle.RelationKeyName.String():        pbtypes.String(bookmark.GetTitle()),
+		bundle.RelationKeySource.String():      pbtypes.String(bookmark.GetUrl()),
+	}}
 }
 
 func (r *Renderer) getBookmarkBlockParams(b *model.Block, details *types.Struct) *BlockParams {

--- a/renderer/bookmark_test.go
+++ b/renderer/bookmark_test.go
@@ -61,7 +61,6 @@ func TestMakeBookmarkRendererParams(t *testing.T) {
 				Id: "block2",
 				Content: &model.BlockContentOfBookmark{
 					Bookmark: &model.BlockContentBookmark{
-						Url:            "https://example.com",
 						TargetObjectId: "object12",
 					},
 				},
@@ -80,7 +79,6 @@ func TestMakeBookmarkRendererParams(t *testing.T) {
 				Id: "block2",
 				Content: &model.BlockContentOfBookmark{
 					Bookmark: &model.BlockContentBookmark{
-						Url:            "https://example.com",
 						TargetObjectId: "object12",
 					},
 				},
@@ -93,7 +91,6 @@ func TestMakeBookmarkRendererParams(t *testing.T) {
 				Id: "block3",
 				Content: &model.BlockContentOfBookmark{
 					Bookmark: &model.BlockContentBookmark{
-						Url:            "::::",
 						TargetObjectId: "object3",
 					},
 				},
@@ -120,6 +117,32 @@ func TestMakeBookmarkRendererParams(t *testing.T) {
 				Id: "block3",
 				Content: &model.BlockContentOfBookmark{
 					Bookmark: &model.BlockContentBookmark{TargetObjectId: "object3"},
+				},
+			},
+			pbFiles: map[string]*pb.SnapshotWithType{
+				filepath.Join("objects", "object3.pb"): {
+					SbType: model.SmartBlockType_Page,
+					Snapshot: &pb.ChangeSnapshot{Data: &model.SmartBlockSnapshotBase{
+						Details: &types.Struct{Fields: map[string]*types.Value{
+							bundle.RelationKeyIconImage.String():   pbtypes.String("favicon3"),
+							bundle.RelationKeyPicture.String():     pbtypes.String("image3"),
+							bundle.RelationKeyDescription.String(): pbtypes.String("description3"),
+							bundle.RelationKeyName.String():        pbtypes.String("name3"),
+							bundle.RelationKeySource.String():      pbtypes.String(""),
+						}},
+					}},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "empty URL in source, try to get from block",
+			block: &model.Block{
+				Id: "block3",
+				Content: &model.BlockContentOfBookmark{
+					Bookmark: &model.BlockContentBookmark{
+						TargetObjectId: "object3",
+						Url:            "https://example.com"},
 				},
 			},
 			pbFiles: map[string]*pb.SnapshotWithType{


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5117/bookmarks-created-from-object-are-not-rendered