### PR TITLE
GO-5198 Fix marks ranges cut

### DIFF
--- a/renderer/markintervaltree/tree.go
+++ b/renderer/markintervaltree/tree.go
@@ -11,6 +11,20 @@ type MarkIntervalTreeNode struct {
 	Right       *MarkIntervalTreeNode
 }
 
+func New(marks []*model.BlockContentTextMark) *MarkIntervalTreeNode {
+	root := &MarkIntervalTreeNode{
+		Mark:        marks[0],
+		MaxUpperVal: marks[0].Range.To,
+	}
+
+	for i := 1; i < len(marks); i++ {
+		root.Insert(marks[i])
+	}
+
+	return root
+
+}
+
 func (r *MarkIntervalTreeNode) Insert(m *model.BlockContentTextMark) {
 	node := r
 	for node != nil {

--- a/renderer/markintervaltree/tree.go
+++ b/renderer/markintervaltree/tree.go
@@ -49,11 +49,17 @@ func rangeOverlap(a, b *model.Range) bool {
 		b.To && a.To > b.From) || (a.From == b.From && a.To == b.To)
 }
 
-func SearchOverlaps(n *MarkIntervalTreeNode, i *model.Range, result *[]*model.BlockContentTextMark) {
+func (r *MarkIntervalTreeNode) SearchOverlaps(i *model.Range) []*model.BlockContentTextMark {
+	marksToApply := make([]*model.BlockContentTextMark, 0)
+	searchOverlaps(r, i, &marksToApply)
+	return marksToApply
+}
+
+func searchOverlaps(n *MarkIntervalTreeNode, i *model.Range, result *[]*model.BlockContentTextMark) {
 	if n == nil || n.MaxUpperVal < i.From {
 		return
 	}
-	SearchOverlaps(n.Left, i, result)
+	searchOverlaps(n.Left, i, result)
 
 	if rangeOverlap(n.Mark.Range, i) {
 		*result = append(*result, n.Mark)
@@ -62,5 +68,5 @@ func SearchOverlaps(n *MarkIntervalTreeNode, i *model.Range, result *[]*model.Bl
 		return
 	}
 
-	SearchOverlaps(n.Right, i, result)
+	searchOverlaps(n.Right, i, result)
 }

--- a/renderer/markintervaltree/tree_test.go
+++ b/renderer/markintervaltree/tree_test.go
@@ -39,17 +39,16 @@ func TestMarkIntervalTree(t *testing.T) {
 			To:   31,
 		},
 	}
-	root := &MarkIntervalTreeNode{
-		Mark: &model.BlockContentTextMark{
-			Range: ranges[0],
-		},
+
+	marks := make([]*model.BlockContentTextMark, 0)
+	for _, r := range ranges {
+		mark := &model.BlockContentTextMark{
+			Range: r,
+		}
+		marks = append(marks, mark)
 	}
 
-	for i := 1; i < len(ranges); i++ {
-		root.Insert(&model.BlockContentTextMark{
-			Range: ranges[i],
-		})
-	}
+	root := New(marks)
 
 	t.Run("simple test", func(t *testing.T) {
 		results := root.SearchOverlaps(&model.Range{

--- a/renderer/markintervaltree/tree_test.go
+++ b/renderer/markintervaltree/tree_test.go
@@ -52,11 +52,10 @@ func TestMarkIntervalTree(t *testing.T) {
 	}
 
 	t.Run("simple test", func(t *testing.T) {
-		results := make([]*model.BlockContentTextMark, 0)
-		SearchOverlaps(root, &model.Range{
+		results := root.SearchOverlaps(&model.Range{
 			From: 17,
 			To:   19,
-		}, &results)
+		})
 
 		expected := []*model.BlockContentTextMark{
 			&model.BlockContentTextMark{
@@ -83,11 +82,10 @@ func TestMarkIntervalTree(t *testing.T) {
 	})
 
 	t.Run("single range", func(t *testing.T) {
-		results := make([]*model.BlockContentTextMark, 0)
-		SearchOverlaps(root, &model.Range{
+		results := root.SearchOverlaps(&model.Range{
 			From: 5,
 			To:   6,
-		}, &results)
+		})
 
 		expected := []*model.BlockContentTextMark{
 			&model.BlockContentTextMark{
@@ -108,11 +106,10 @@ func TestMarkIntervalTree(t *testing.T) {
 			MaxUpperVal: ranges[0].To,
 		}
 
-		results := make([]*model.BlockContentTextMark, 0)
-		SearchOverlaps(singleRoot, &model.Range{
+		results := singleRoot.SearchOverlaps(&model.Range{
 			From: 5,
 			To:   6,
-		}, &results)
+		})
 
 		expected := []*model.BlockContentTextMark{
 			&model.BlockContentTextMark{

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -172,7 +172,7 @@ func NewRenderer(config RenderConfig) (r *Renderer, err error) {
 	defer func() {
 		if p := recover(); p != nil {
 			stack := string(debug.Stack())
-			err = fmt.Errorf("panic: %v, pablishFilesPath: %s, stack: %s", p, r.Config.PublishFilesPath, stack)
+			err = fmt.Errorf("panic: %v, publishFilesPath: %s, stack: %s", p, r.Config.PublishFilesPath, stack)
 			log.Error("panic recover", zap.String("where", "NewRenderer()"), zap.Error(err), zap.String("stack", stack))
 			return
 		}
@@ -238,7 +238,7 @@ func (r *Renderer) Render(writer io.Writer) (err error) {
 	defer func() {
 		if p := recover(); p != nil {
 			stack := string(debug.Stack())
-			err = fmt.Errorf("panic: %v, pablishFilesPath: %s, stack: %s", p, r.Config.PublishFilesPath, stack)
+			err = fmt.Errorf("panic: %v, publishFilesPath: %s, stack: %s", p, r.Config.PublishFilesPath, stack)
 			log.Error("panic recover", zap.String("where", "Render()"), zap.Error(err), zap.String("stack", stack))
 		}
 	}()

--- a/renderer/text.go
+++ b/renderer/text.go
@@ -232,8 +232,6 @@ func (r *Renderer) makeTextBlockParams(b *model.Block) (params *BlockParams) {
 		marks := blockText.GetMarks().Marks
 		text = r.applyNonOverlapingMarks(style, text, marks)
 		text = replaceNewlineBr(text)
-		log.Debug("final text", zap.String("m", text))
-
 		textComp = PlainTextWrapTemplate(templ.Raw(text))
 	} else {
 		fields := b.GetFields()
@@ -248,7 +246,6 @@ func (r *Renderer) makeTextBlockParams(b *model.Block) (params *BlockParams) {
 		innerFlex = append(innerFlex, externalComp, textComp)
 	case model.BlockContentText_Numbered:
 		number := r.BlockNumbers[b.Id]
-		log.Debug("number", zap.Int("num", number), zap.String("id", b.Id))
 		externalComp := NumberMarkerTemplate(fmt.Sprintf("%d", number))
 		innerFlex = append(innerFlex, externalComp, textComp)
 	case model.BlockContentText_Marked:

--- a/renderer/text.go
+++ b/renderer/text.go
@@ -160,19 +160,6 @@ func makeMarksRangeRay(marks []*model.BlockContentTextMark, textLen int32) []int
 	return rangeRay
 }
 
-func buildMarksIntervalTree(marks []*model.BlockContentTextMark) *markintervaltree.MarkIntervalTreeNode {
-	root := &markintervaltree.MarkIntervalTreeNode{
-		Mark:        marks[0],
-		MaxUpperVal: marks[0].Range.To,
-	}
-
-	for i := 1; i < len(marks); i++ {
-		root.Insert(marks[i])
-	}
-
-	return root
-}
-
 // - make borders
 //   - make set from ranges, from-to
 //   - sort
@@ -188,7 +175,7 @@ func (r *Renderer) applyNonOverlapingMarks(style model.BlockContentTextStyle, te
 
 	// convert to JSRunes to cut marks.Range in the same way as JS does
 	rText := toJSRunes(text)
-	marksIntervalTree := buildMarksIntervalTree(marks)
+	marksIntervalTree := markintervaltree.New(marks)
 	rangeRay := makeMarksRangeRay(marks, int32(len(rText)))
 
 	for i := 0; i < len(rangeRay)-1; i++ {

--- a/renderer/text.go
+++ b/renderer/text.go
@@ -185,6 +185,8 @@ func (r *Renderer) applyNonOverlapingMarks(style model.BlockContentTextStyle, te
 	}
 
 	var markedText strings.Builder
+
+	// convert to JSRunes to cut marks.Range in the same way as JS does
 	rText := toJSRunes(text)
 	marksIntervalTree := buildMarksIntervalTree(marks)
 	rangeRay := makeMarksRangeRay(marks, int32(len(rText)))


### PR DESCRIPTION
- use JSRunes instead of utf16 decode to runes to cut ranges properly
- applyMark refactoring 
- markintervaltree refactoring